### PR TITLE
Added `asRight()` and `asLeft()` methods to `EitherAssert`

### DIFF
--- a/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractEitherAssert.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractEitherAssert.kt
@@ -1,7 +1,6 @@
 package `in`.rcard.assertj.arrowcore
 
 import arrow.core.Either
-import arrow.core.Option
 import `in`.rcard.assertj.arrowcore.errors.EitherShouldBeLeft.Companion.shouldBeLeft
 import `in`.rcard.assertj.arrowcore.errors.EitherShouldBeRight.Companion.shouldBeRight
 import `in`.rcard.assertj.arrowcore.errors.EitherShouldContain.Companion.shouldContainOnLeft

--- a/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractEitherAssert.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractEitherAssert.kt
@@ -168,6 +168,18 @@ abstract class AbstractEitherAssert<
         return myself
     }
 
+    /**
+     * Verifies that the actual [Either] is not null and contains a left-sided value and returns an Object assertion
+     * that allows chaining (object) assertions on the value.
+     *
+     * @since 0.2.0
+     * @return a new [AbstractObjectAssert] for assertions chaining on the left-sided value of the [Either].
+     */
+    fun asLeft(): AbstractObjectAssert<*, LEFT> {
+        assertIsLeft()
+        return Assertions.assertThat(actual.leftOrNull())
+    }
+
     private fun assertIsLeft() {
         isNotNull
         if (!actual.isLeft()) {

--- a/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractEitherAssert.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractEitherAssert.kt
@@ -95,6 +95,10 @@ abstract class AbstractEitherAssert<
      *
      * @since 0.1.0
      */
+    @Deprecated(
+        "hasRightValueSatisfying can be replaced using the method asRight() and chaining assertions on the returned object.",
+        ReplaceWith("asRight().satisfies(requirement)"),
+    )
     fun hasRightValueSatisfying(requirement: (RIGHT) -> Unit): SELF {
         assertIsRight()
         actual.onRight { requirement(it) }
@@ -162,6 +166,10 @@ abstract class AbstractEitherAssert<
      * @return this assertion object.
      * @since 0.1.0
      */
+    @Deprecated(
+        "hasLeftValueSatisfying can be replaced using the method asLeft() and chaining assertions on the returned object.",
+        ReplaceWith("asLeft().satisfies(requirement)"),
+    )
     fun hasLeftValueSatisfying(requirement: (LEFT) -> Unit): SELF {
         assertIsLeft()
         actual.onLeft { requirement(it) }

--- a/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractEitherAssert.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractEitherAssert.kt
@@ -1,6 +1,7 @@
 package `in`.rcard.assertj.arrowcore
 
 import arrow.core.Either
+import arrow.core.Option
 import `in`.rcard.assertj.arrowcore.errors.EitherShouldBeLeft.Companion.shouldBeLeft
 import `in`.rcard.assertj.arrowcore.errors.EitherShouldBeRight.Companion.shouldBeRight
 import `in`.rcard.assertj.arrowcore.errors.EitherShouldContain.Companion.shouldContainOnLeft
@@ -8,6 +9,7 @@ import `in`.rcard.assertj.arrowcore.errors.EitherShouldContain.Companion.shouldC
 import `in`.rcard.assertj.arrowcore.errors.EitherShouldContainInstanceOf.Companion.shouldContainOnLeftInstanceOf
 import `in`.rcard.assertj.arrowcore.errors.EitherShouldContainInstanceOf.Companion.shouldContainOnRightInstanceOf
 import org.assertj.core.api.AbstractObjectAssert
+import org.assertj.core.api.Assertions
 import org.assertj.core.internal.ComparisonStrategy
 import org.assertj.core.internal.StandardComparisonStrategy
 
@@ -98,6 +100,18 @@ abstract class AbstractEitherAssert<
         assertIsRight()
         actual.onRight { requirement(it) }
         return myself
+    }
+
+    /**
+     * Verifies that the actual [Either] is not null and contains a right-sided value and returns an Object assertion
+     * that allows chaining (object) assertions on the value.
+     *
+     * @since 0.2.0
+     * @return a new [AbstractObjectAssert] for assertions chaining on the right-sided value of the [Either].
+     */
+    fun asRight(): AbstractObjectAssert<*, RIGHT> {
+        assertIsRight()
+        return Assertions.assertThat(actual.getOrNull())
     }
 
     private fun assertIsRight() {

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_asLeft_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_asLeft_Test.kt
@@ -1,0 +1,35 @@
+package `in`.rcard.assertj.arrowcore
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import `in`.rcard.assertj.arrowcore.EitherAssert.Companion.assertThat
+import `in`.rcard.assertj.arrowcore.errors.EitherShouldBeLeft.Companion.shouldBeLeft
+import org.assertj.core.api.Assertions
+import org.assertj.core.util.FailureMessages
+import org.junit.jupiter.api.Test
+
+internal class EitherAssert_asLeft_Test {
+
+    @Test
+    internal fun `should return a valid Object assert if the either contains a left-sided value`() {
+        val actualLeftValue: Either<Int, Nothing> = 42.left()
+        assertThat(actualLeftValue).asLeft().isEqualTo(42)
+    }
+
+    @Test
+    internal fun `should fail if the either contains a right-sided value`() {
+        val actualRightValue: Either<Nothing, String> = "42".right()
+        Assertions.assertThatThrownBy { assertThat(actualRightValue).asLeft() }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldBeLeft(actualRightValue).create())
+    }
+
+    @Test
+    internal fun `should fail if the either is null`() {
+        val actualLeftValue: Either<Int, Nothing>? = null
+        Assertions.assertThatThrownBy { assertThat(actualLeftValue).asLeft() }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(FailureMessages.actualIsNull())
+    }
+}

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_asRight_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_asRight_Test.kt
@@ -1,0 +1,35 @@
+package `in`.rcard.assertj.arrowcore
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import `in`.rcard.assertj.arrowcore.EitherAssert.Companion.assertThat
+import `in`.rcard.assertj.arrowcore.errors.EitherShouldBeRight.Companion.shouldBeRight
+import org.assertj.core.api.Assertions
+import org.assertj.core.util.FailureMessages
+import org.junit.jupiter.api.Test
+
+internal class EitherAssert_asRight_Test {
+
+    @Test
+    internal fun `should return a valid Object assert if the either contains a right-sided value`() {
+        val actualRightValue: Either<Nothing, Int> = 42.right()
+        assertThat(actualRightValue).asRight().isEqualTo(42)
+    }
+
+    @Test
+    internal fun `should fail if the either contains a left-sided value`() {
+        val actualLeftValue: Either<String, Nothing> = "42".left()
+        Assertions.assertThatThrownBy { assertThat(actualLeftValue).asRight() }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldBeRight(actualLeftValue).create())
+    }
+
+    @Test
+    internal fun `should fail if the either is null`() {
+        val actualRightValue: Either<Nothing, Int>? = null
+        Assertions.assertThatThrownBy { assertThat(actualRightValue).asRight() }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(FailureMessages.actualIsNull())
+    }
+}


### PR DESCRIPTION
I renamed the suggested methods into `asRight()` and `asLeft()` respectively.