### PR TITLE
feat(58): Added methods to extract the result and the error of the execution of a function in the `Raise<E>` context.

### DIFF
--- a/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractRaiseAssert.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractRaiseAssert.kt
@@ -8,6 +8,8 @@ import `in`.rcard.assertj.arrowcore.errors.RaiseShouldSucceedButFailed.Companion
 import `in`.rcard.assertj.arrowcore.errors.RaiseShouldSucceedWith.Companion.shouldSucceedWith
 import `in`.rcard.assertj.arrowcore.errors.RaiseShouldSucceedWithButFailed.Companion.shouldSucceedWithButFailed
 import org.assertj.core.api.AbstractAssert
+import org.assertj.core.api.AbstractObjectAssert
+import org.assertj.core.api.Assertions
 import org.assertj.core.internal.ComparisonStrategy
 import org.assertj.core.internal.StandardComparisonStrategy
 
@@ -125,6 +127,11 @@ abstract class AbstractRaiseAssert<
                     shouldFailButSucceedsWith((actual as RaiseResult.Success<VALUE>).value),
                 )
         }
+
+    fun result(): AbstractObjectAssert<*, VALUE> {
+        succeeds()
+        return Assertions.assertThat((actual as RaiseResult.Success<VALUE>).value)
+    }
 }
 
 sealed interface RaiseResult<out ERROR : Any, out VALUE : Any> {

--- a/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractRaiseAssert.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractRaiseAssert.kt
@@ -128,11 +128,27 @@ abstract class AbstractRaiseAssert<
                 )
         }
 
+    /**
+     * Verifies that the actual function in the [Raise] context succeeds and returns an Object assertion
+     * that allows chaining (object) assertions on the returned value.
+     *
+     * @since 1.1.0
+     * @return a new [AbstractObjectAssert] for assertions chaining on the result value of the function
+     * in the [Raise] context.
+     */
     fun result(): AbstractObjectAssert<*, VALUE> {
         succeeds()
         return Assertions.assertThat((actual as RaiseResult.Success<VALUE>).value)
     }
 
+    /**
+     * Verifies that the actual function in the [Raise] context fails and returns an Object assertion
+     * that allows chaining (object) assertions on the raised error.
+     *
+     * @since 1.1.0
+     * @return a new [AbstractObjectAssert] for assertions chaining on the raised error of the function
+     * in the [Raise] context.
+     */
     fun error(): AbstractObjectAssert<*, ERROR> {
         fails()
         return Assertions.assertThat((actual as RaiseResult.Failure<ERROR>).error)

--- a/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractRaiseAssert.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractRaiseAssert.kt
@@ -132,6 +132,11 @@ abstract class AbstractRaiseAssert<
         succeeds()
         return Assertions.assertThat((actual as RaiseResult.Success<VALUE>).value)
     }
+
+    fun error(): AbstractObjectAssert<*, ERROR> {
+        fails()
+        return Assertions.assertThat((actual as RaiseResult.Failure<ERROR>).error)
+    }
 }
 
 sealed interface RaiseResult<out ERROR : Any, out VALUE : Any> {

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/RaiseAssert_error_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/RaiseAssert_error_Test.kt
@@ -1,0 +1,32 @@
+package `in`.rcard.assertj.arrowcore
+
+import `in`.rcard.assertj.arrowcore.Dummy.aFunctionThatRaisesAnError
+import `in`.rcard.assertj.arrowcore.Dummy.aFunctionThatThrowsAnException
+import `in`.rcard.assertj.arrowcore.Dummy.aFunctionWithContext
+import `in`.rcard.assertj.arrowcore.RaiseAssert.Companion.assertThat
+import `in`.rcard.assertj.arrowcore.errors.RaiseShouldFailButSucceeds.Companion.shouldFailButSucceedsWith
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+internal class RaiseAssert_error_Test {
+    @Test
+    internal fun `should return a valid Object Assert if the Raise raises an error`() {
+        assertThat { aFunctionThatRaisesAnError() }.error().isEqualTo("LOGICAL ERROR")
+    }
+
+    @Test
+    internal fun `should fails if the Raise returns a value`() {
+        Assertions
+            .assertThatThrownBy { assertThat { aFunctionWithContext(42) }.error() }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldFailButSucceedsWith(42).create())
+    }
+
+    @Test
+    internal fun `should rethrow the inner exception`() {
+        Assertions
+            .assertThatThrownBy { assertThat { aFunctionThatThrowsAnException() }.error() }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessage("AN EXCEPTION")
+    }
+}

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/RaiseAssert_result_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/RaiseAssert_result_Test.kt
@@ -1,0 +1,15 @@
+package `in`.rcard.assertj.arrowcore
+
+import org.junit.jupiter.api.Test
+
+internal class RaiseAssert_result_Test {
+    @Test
+    fun `should return a valid Object Assert if the Raise returns a result`() {
+        TODO("Not yet implemented")
+    }
+
+    @Test
+    fun `should fails if the Raise raised an error`() {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/RaiseAssert_result_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/RaiseAssert_result_Test.kt
@@ -1,15 +1,32 @@
 package `in`.rcard.assertj.arrowcore
 
+import `in`.rcard.assertj.arrowcore.Dummy.aFunctionThatRaisesAnError
+import `in`.rcard.assertj.arrowcore.Dummy.aFunctionThatThrowsAnException
+import `in`.rcard.assertj.arrowcore.Dummy.aFunctionWithContext
+import `in`.rcard.assertj.arrowcore.RaiseAssert.Companion.assertThat
+import `in`.rcard.assertj.arrowcore.errors.RaiseShouldSucceedButFailed.Companion.shouldSucceedButFailed
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 
 internal class RaiseAssert_result_Test {
     @Test
-    fun `should return a valid Object Assert if the Raise returns a result`() {
-        TODO("Not yet implemented")
+    internal fun `should return a valid Object Assert if the Raise returns a result`() {
+        assertThat { aFunctionWithContext(42) }.result().isEqualTo(42)
     }
 
     @Test
-    fun `should fails if the Raise raised an error`() {
-        TODO("Not yet implemented")
+    internal fun `should fails if the Raise raised an error`() {
+        Assertions
+            .assertThatThrownBy { assertThat { aFunctionThatRaisesAnError() }.result() }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldSucceedButFailed("LOGICAL ERROR").create())
+    }
+
+    @Test
+    internal fun `should rethrow the inner exception`() {
+        Assertions
+            .assertThatThrownBy { assertThat { aFunctionThatThrowsAnException() }.result() }
+            .isInstanceOf(RuntimeException::class.java)
+            .hasMessage("AN EXCEPTION")
     }
 }


### PR DESCRIPTION
Closes #58 