### PR TITLE
fix: make error/value types in RaiseAssert nullable

### DIFF
--- a/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractRaiseAssert.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractRaiseAssert.kt
@@ -23,8 +23,8 @@ import org.assertj.core.internal.StandardComparisonStrategy
  */
 abstract class AbstractRaiseAssert<
     SELF : AbstractRaiseAssert<SELF, ERROR, VALUE>,
-    ERROR : Any,
-    VALUE : Any,
+    ERROR : Any?,
+    VALUE : Any?,
 > internal constructor(
     raiseResult: RaiseResult<ERROR, VALUE>,
 ) : AbstractAssert<
@@ -155,12 +155,12 @@ abstract class AbstractRaiseAssert<
     }
 }
 
-sealed interface RaiseResult<out ERROR : Any, out VALUE : Any> {
-    data class Success<out VALUE : Any>(
+sealed interface RaiseResult<out ERROR : Any?, out VALUE : Any?> {
+    data class Success<out VALUE : Any?>(
         val value: VALUE,
     ) : RaiseResult<Nothing, VALUE>
 
-    data class Failure<out ERROR : Any>(
+    data class Failure<out ERROR : Any?>(
         val error: ERROR,
     ) : RaiseResult<ERROR, Nothing>
 

--- a/src/main/kotlin/in/rcard/assertj/arrowcore/RaiseAssert.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/RaiseAssert.kt
@@ -22,11 +22,11 @@ import kotlin.experimental.ExperimentalTypeInference
  *
  * @since 0.2.0
  */
-class RaiseAssert<ERROR : Any, VALUE : Any>(
+class RaiseAssert<ERROR : Any?, VALUE : Any?>(
     raiseResult: RaiseResult<ERROR, VALUE>,
 ) : AbstractRaiseAssert<RaiseAssert<ERROR, VALUE>, ERROR, VALUE>(raiseResult) {
     companion object {
-        inline fun <ERROR : Any, VALUE : Any> assertThat(
+        inline fun <ERROR : Any?, VALUE : Any?> assertThat(
             @BuilderInference lambda: Raise<ERROR>.() -> VALUE,
         ): RaiseAssert<ERROR, VALUE> {
             val raiseResult =
@@ -54,7 +54,7 @@ class RaiseAssert<ERROR : Any, VALUE : Any>(
          * @param shouldRaiseThrowable the function to be executed in the [Raise] context.
          * @return the [AbstractThrowableAssert] to be used to verify the exception.
          */
-        inline fun <ERROR : Any, VALUE : Any> assertThatThrownBy(
+        inline fun <ERROR : Any?, VALUE : Any?> assertThatThrownBy(
             @BuilderInference shouldRaiseThrowable: Raise<ERROR>.() -> VALUE,
         ): AbstractThrowableAssert<*, out Throwable> {
             val throwable: Throwable? =
@@ -81,7 +81,7 @@ class RaiseAssert<ERROR : Any, VALUE : Any>(
          * @param shouldRaiseError the function to be executed in the [Raise] context.
          * @return the [AbstractObjectAssert] to be used to verify the error.
          */
-        inline fun <ERROR : Any, VALUE : Any> assertThatRaisedBy(
+        inline fun <ERROR : Any?, VALUE : Any?> assertThatRaisedBy(
             @BuilderInference shouldRaiseError: Raise<ERROR>.() -> VALUE,
         ): AbstractObjectAssert<*, out ERROR> {
             val error =


### PR DESCRIPTION
It's a valid case that function returns null value. The same can probably be stated regarding the error value. While here I cannot imagine a use case (yet) I think it's better for the lib to be as general as possible.