### PR TITLE
Allow for asserting on Eithers containing null values within them

### DIFF
--- a/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractEitherAssert.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/AbstractEitherAssert.kt
@@ -25,8 +25,8 @@ import org.assertj.core.internal.StandardComparisonStrategy
  */
 abstract class AbstractEitherAssert<
     SELF : AbstractEitherAssert<SELF, LEFT, RIGHT>,
-    LEFT : Any,
-    RIGHT : Any,
+    LEFT : Any?,
+    RIGHT : Any?,
 > internal constructor(
     either: Either<LEFT, RIGHT>?,
 ) : AbstractObjectAssert<SELF, Either<LEFT, RIGHT>>(either, AbstractEitherAssert::class.java) {

--- a/src/main/kotlin/in/rcard/assertj/arrowcore/EitherAssert.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/EitherAssert.kt
@@ -10,10 +10,10 @@ import arrow.core.Either
  * @author Riccardo Cardin
  * @since 0.0.1
  */
-class EitherAssert<LEFT : Any, RIGHT : Any> private constructor(either: Either<LEFT, RIGHT>?) :
+class EitherAssert<LEFT : Any?, RIGHT : Any?> private constructor(either: Either<LEFT, RIGHT>?) :
     AbstractEitherAssert<EitherAssert<LEFT, RIGHT>, LEFT, RIGHT>(either) {
     companion object {
-        fun <LEFT : Any, RIGHT : Any> assertThat(actual: Either<LEFT, RIGHT>?): EitherAssert<LEFT, RIGHT> =
+        fun <LEFT : Any?, RIGHT : Any?> assertThat(actual: Either<LEFT, RIGHT>?): EitherAssert<LEFT, RIGHT> =
             EitherAssert(actual)
     }
 }

--- a/src/main/kotlin/in/rcard/assertj/arrowcore/errors/EitherShouldContain.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/errors/EitherShouldContain.kt
@@ -9,7 +9,7 @@ import org.assertj.core.error.BasicErrorMessageFactory
  * @author Riccardo Cardin
  * @since 0.0.1
  */
-internal class EitherShouldContain private constructor(message: String, actual: Either<Any, Any>, expected: Any) :
+internal class EitherShouldContain private constructor(message: String, actual: Either<Any?, Any?>, expected: Any?) :
     BasicErrorMessageFactory(message, actual, expected) {
 
     companion object {
@@ -28,7 +28,7 @@ internal class EitherShouldContain private constructor(message: String, actual: 
          * @param RIGHT         the type of the value contained in the [Either] on the right side.
          * @return an error message factory
          */
-        internal fun <LEFT : Any, RIGHT : Any> shouldContainOnRight(
+        internal fun <LEFT : Any?, RIGHT : Any?> shouldContainOnRight(
             actual: Either<LEFT, RIGHT>,
             expectedValue: RIGHT,
         ): EitherShouldContain = EitherShouldContain(
@@ -46,7 +46,7 @@ internal class EitherShouldContain private constructor(message: String, actual: 
          * @param RIGHT       the type of the value contained in the [Either] on the right side.
          * @return an error message factory
          */
-        internal fun <LEFT : Any, RIGHT : Any> shouldContainOnLeft(
+        internal fun <LEFT : Any?, RIGHT : Any?> shouldContainOnLeft(
             actual: Either<LEFT, RIGHT>,
             expectedValue: RIGHT,
         ): EitherShouldContain = EitherShouldContain(

--- a/src/main/kotlin/in/rcard/assertj/arrowcore/errors/EitherShouldContainInstanceOf.kt
+++ b/src/main/kotlin/in/rcard/assertj/arrowcore/errors/EitherShouldContainInstanceOf.kt
@@ -30,7 +30,7 @@ internal class EitherShouldContainInstanceOf private constructor(message: String
          * @throws java.lang.NullPointerException if either is null.
          */
         internal fun shouldContainOnRightInstanceOf(
-            actual: Either<Any, Any>,
+            actual: Either<Any?, Any?>,
             expectedClass: Class<*>,
         ): EitherShouldContainInstanceOf =
             actual.fold(
@@ -47,14 +47,14 @@ internal class EitherShouldContainInstanceOf private constructor(message: String
                         EXPECTING_TO_CONTAIN_DIFFERENT_INSTANCE.format(
                             actual.javaClass.simpleName,
                             expectedClass.name,
-                            rightValue.javaClass.name,
+                            rightValue?.javaClass?.name ?: "null",
                         ),
                     )
                 },
             )
 
         internal fun shouldContainOnLeftInstanceOf(
-            actual: Either<Any, Any>,
+            actual: Either<Any?, Any?>,
             expectedClass: Class<*>,
         ): EitherShouldContainInstanceOf =
             actual.fold(
@@ -63,7 +63,7 @@ internal class EitherShouldContainInstanceOf private constructor(message: String
                         EXPECTING_TO_CONTAIN_DIFFERENT_INSTANCE.format(
                             actual.javaClass.simpleName,
                             expectedClass.name,
-                            leftValue.javaClass.name,
+                            leftValue?.javaClass?.name ?: "null",
                         ),
                     )
                 },

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_asLeft_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_asLeft_Test.kt
@@ -18,6 +18,12 @@ internal class EitherAssert_asLeft_Test {
     }
 
     @Test
+    internal fun `should return a valid Object assert if the either contains a left-sided null`() {
+        val actualLeftValue: Either<Int?, Nothing> = null.left()
+        assertThat(actualLeftValue).asLeft().isEqualTo(null)
+    }
+
+    @Test
     internal fun `should fail if the either contains a right-sided value`() {
         val actualRightValue: Either<Nothing, String> = "42".right()
         Assertions.assertThatThrownBy { assertThat(actualRightValue).asLeft() }
@@ -26,7 +32,15 @@ internal class EitherAssert_asLeft_Test {
     }
 
     @Test
-    internal fun `should fail if the either is null`() {
+    internal fun `should fail if the either contains a right-sided null`() {
+        val actualRightValue: Either<Nothing, String?> = null.right()
+        Assertions.assertThatThrownBy { assertThat(actualRightValue).asLeft() }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldBeLeft(actualRightValue).create())
+    }
+
+    @Test
+    internal fun `should fail if the either itself is null`() {
         val actualLeftValue: Either<Int, Nothing>? = null
         Assertions.assertThatThrownBy { assertThat(actualLeftValue).asLeft() }
             .isInstanceOf(AssertionError::class.java)

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_asRight_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_asRight_Test.kt
@@ -18,6 +18,12 @@ internal class EitherAssert_asRight_Test {
     }
 
     @Test
+    internal fun `should return a valid Object assert if either contains a right-sided null`() {
+        val actualRightValue: Either<Nothing, Int?> = null.right()
+        assertThat(actualRightValue).asRight().isEqualTo(null)
+    }
+
+    @Test
     internal fun `should fail if the either contains a left-sided value`() {
         val actualLeftValue: Either<String, Nothing> = "42".left()
         Assertions.assertThatThrownBy { assertThat(actualLeftValue).asRight() }
@@ -26,7 +32,15 @@ internal class EitherAssert_asRight_Test {
     }
 
     @Test
-    internal fun `should fail if the either is null`() {
+    internal fun `should fail if either contains a left-sided null`() {
+        val actualLeftValue: Either<String?, Nothing> = null.left()
+        Assertions.assertThatThrownBy { assertThat(actualLeftValue).asRight() }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldBeRight(actualLeftValue).create())
+    }
+
+    @Test
+    internal fun `should fail if the either itself is null`() {
         val actualRightValue: Either<Nothing, Int>? = null
         Assertions.assertThatThrownBy { assertThat(actualRightValue).asRight() }
             .isInstanceOf(AssertionError::class.java)

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_containsOnLeftInstanceOf_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_containsOnLeftInstanceOf_Test.kt
@@ -36,10 +36,38 @@ internal class EitherAssert_containsOnLeftInstanceOf_Test {
     }
 
     @Test
+    internal fun `should fail if either contains a right-sided null`() {
+        val actual: Either<Any, String?> = null.right()
+        Assertions.assertThatThrownBy {
+            assertThat(actual).containsLeftInstanceOf(
+                Any::class.java,
+            )
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldBeLeft(actual).create())
+    }
+
+    @Test
     internal fun `should pass if either contains required type on left`() {
         val actual: Either<String, Nothing> = "something".left()
         assertThat(actual)
             .containsLeftInstanceOf(String::class.java)
+    }
+
+    @Test
+    internal fun `should fail if either contains null value for type on left`() {
+        val actual: Either<String?, Nothing> = null.left()
+        Assertions.assertThatThrownBy {
+            assertThat(actual)
+                .containsLeftInstanceOf(String::class.java)
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(
+                shouldContainOnLeftInstanceOf(
+                    actual,
+                    String::class.java
+                ).create()
+            )
     }
 
     @Test

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_containsOnLeft_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_containsOnLeft_Test.kt
@@ -5,6 +5,7 @@ import arrow.core.left
 import arrow.core.right
 import `in`.rcard.assertj.arrowcore.errors.EitherShouldBeLeft.Companion.shouldBeLeft
 import `in`.rcard.assertj.arrowcore.errors.EitherShouldContain.Companion.shouldContainOnLeft
+import `in`.rcard.assertj.arrowcore.errors.EitherShouldContain.Companion.shouldContainOnRight
 import org.assertj.core.api.Assertions
 import org.assertj.core.util.FailureMessages.actualIsNull
 import org.junit.jupiter.api.Test
@@ -29,6 +30,12 @@ internal class EitherAssert_containsOnLeft_Test {
     }
 
     @Test
+    internal fun `should pass if either contains an expected null on left side`() {
+        val leftValue = null.left()
+        EitherAssert.assertThat(leftValue).containsOnLeft(null)
+    }
+
+    @Test
     internal fun `should fail if either does not contain expected value on left side`() {
         val actual: Either<String, Nothing> = "something".left()
         val expectedValue = "nothing"
@@ -42,8 +49,34 @@ internal class EitherAssert_containsOnLeft_Test {
     }
 
     @Test
+    internal fun `should fail with informative error message if null is contained on left side and a value was expected`() {
+        val actual: Either<String?, Nothing> = null.left()
+        val expectedValue = "something"
+        Assertions.assertThatThrownBy {
+            EitherAssert.assertThat(actual).containsOnLeft(
+                expectedValue,
+            )
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldContainOnLeft(actual, expectedValue).create())
+    }
+
+    @Test
     internal fun `should fail if either is right`() {
         val actual: Either<String, String> = "nothing".right()
+        val expectedValue = "something"
+        Assertions.assertThatThrownBy {
+            EitherAssert.assertThat(actual).containsOnLeft(
+                expectedValue,
+            )
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldBeLeft(actual).create())
+    }
+
+    @Test
+    internal fun `should fail if either right-sided value is null`() {
+        val actual: Either<String, String?> = null.right()
         val expectedValue = "something"
         Assertions.assertThatThrownBy {
             EitherAssert.assertThat(actual).containsOnLeft(

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_containsOnRightInstanceOf_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_containsOnRightInstanceOf_Test.kt
@@ -49,6 +49,34 @@ internal class EitherAssert_containsOnRightInstanceOf_Test {
     }
 
     @Test
+    internal fun `should fail if either contains a left-sided null`() {
+        val actual: Either<String?, Any> = null.left()
+        Assertions.assertThatThrownBy {
+            assertThat(actual).containsRightInstanceOf(
+                Any::class.java,
+            )
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldBeRight(actual).create())
+    }
+
+    @Test
+    internal fun `should fail if either contains null value for type on right`() {
+        val actual: Either<Nothing, String?> = null.right()
+        Assertions.assertThatThrownBy {
+            assertThat(actual)
+                .containsRightInstanceOf(String::class.java)
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(
+                shouldContainOnRightInstanceOf(
+                    actual,
+                    String::class.java
+                ).create()
+            )
+    }
+
+    @Test
     internal fun `should pass if either contains required type subclass on right`() {
         val actual = Child().right()
         assertThat(actual).containsRightInstanceOf(Parent::class.java)

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_containsOnRight_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_containsOnRight_Test.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 
 internal class EitherAssert_containsOnRight_Test {
     @Test
-    internal fun `should fail when either is null`() {
+    internal fun `should fail when either itself is null`() {
         val rightValue: Either<Nothing, String>? = null
         Assertions.assertThatThrownBy {
             EitherAssert.assertThat(rightValue).containsOnRight(
@@ -29,6 +29,12 @@ internal class EitherAssert_containsOnRight_Test {
     }
 
     @Test
+    internal fun `should pass if either contains a null on right side`() {
+        val rightValue = null.right()
+        EitherAssert.assertThat(rightValue).containsOnRight(null)
+    }
+
+    @Test
     internal fun should_fail_if_either_is_left() {
         val actual: Either<String, String> = "nothing".left()
         val expectedValue = "something"
@@ -40,8 +46,30 @@ internal class EitherAssert_containsOnRight_Test {
     }
 
     @Test
+    internal fun `should fail if either contains a left sided null`() {
+        val actual: Either<String?, String> = null.left()
+        val expectedValue = "something"
+        Assertions.assertThatThrownBy {
+            EitherAssert.assertThat(actual).containsOnRight(expectedValue)
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldBeRight(actual).create())
+    }
+
+    @Test
     internal fun `should fail if either does not contain expected value on right side`() {
         val actual: Either<Nothing, String> = "something".right()
+        val expectedValue = "nothing"
+        Assertions.assertThatThrownBy {
+            EitherAssert.assertThat(actual).containsOnRight(expectedValue)
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldContainOnRight(actual, expectedValue).create())
+    }
+
+    @Test
+    internal fun `should fail with informative error message if either contains null on right but a value was expected`() {
+        val actual: Either<Nothing, String?> = null.right()
         val expectedValue = "nothing"
         Assertions.assertThatThrownBy {
             EitherAssert.assertThat(actual).containsOnRight(expectedValue)

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_hasLeftValueSatisfying_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_hasLeftValueSatisfying_Test.kt
@@ -1,6 +1,7 @@
 package `in`.rcard.assertj.arrowcore
 
 import arrow.core.Either
+import arrow.core.right
 import `in`.rcard.assertj.arrowcore.errors.EitherShouldBeLeft
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
@@ -27,11 +28,19 @@ internal class EitherAssert_hasLeftValueSatisfying_Test {
     }
 
     @Test
+    internal fun `should fail if either is right and null`() {
+        val actual: Either<Int, String?> = null.right()
+        Assertions.assertThatThrownBy { EitherAssert.assertThat(actual).hasLeftValueSatisfying { } }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(EitherShouldBeLeft.shouldBeLeft(actual).create())
+    }
+
+    @Test
     internal fun `should fail if consumer fails`() {
         val actual: Either<Int, String> = Either.Left(42)
         Assertions.assertThatThrownBy { EitherAssert.assertThat(actual).hasLeftValueSatisfying { assertThat(it).isEqualTo(24) } }
             .isInstanceOf(AssertionError::class.java)
-            .hasMessage(("\nexpected: 24\n but was: 42"))
+            .hasMessage(("${System.lineSeparator()}expected: 24${System.lineSeparator()} but was: 42"))
     }
 
     @Test

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_hasRightValueSatisfying_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_hasRightValueSatisfying_Test.kt
@@ -1,6 +1,7 @@
 package `in`.rcard.assertj.arrowcore
 
 import arrow.core.Either
+import arrow.core.left
 import `in`.rcard.assertj.arrowcore.errors.EitherShouldBeRight.Companion.shouldBeRight
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -27,11 +28,19 @@ internal class EitherAssert_hasRightValueSatisfying_Test {
     }
 
     @Test
+    internal fun `should fail if either is left and contains a null value`() {
+        val actual: Either<Int?, String> = null.left()
+        assertThatThrownBy { EitherAssert.assertThat(actual).hasRightValueSatisfying { } }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldBeRight(actual).create())
+    }
+
+    @Test
     internal fun `should fail if consumer fails`() {
         val actual: Either<Int, String> = Either.Right("something")
         assertThatThrownBy { EitherAssert.assertThat(actual).hasRightValueSatisfying { assertThat(it).isEqualTo("something else") } }
             .isInstanceOf(AssertionError::class.java)
-            .hasMessage(("\nexpected: \"something else\"\n but was: \"something\""))
+            .hasMessage(("${System.lineSeparator()}expected: \"something else\"${System.lineSeparator()} but was: \"something\""))
     }
 
     @Test

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_isLeft_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_isLeft_Test.kt
@@ -29,9 +29,27 @@ internal class EitherAssert_isLeft_Test {
     }
 
     @Test
+    internal fun `should pass if either is left-sided null`() {
+        // GIVEN
+        val leftValue = null.left()
+        // WHEN/THEN
+        EitherAssert.assertThat(leftValue).isLeft()
+    }
+
+    @Test
     internal fun `should fail if either is right`() {
         // GIVEN
         val rightValue = 42.right()
+        // WHEN/THEN
+        Assertions.assertThatThrownBy { EitherAssert.assertThat(rightValue).isLeft() }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldBeLeft(rightValue).create())
+    }
+
+    @Test
+    internal fun `should fail if either is right and null`() {
+        // GIVEN
+        val rightValue = null.right()
         // WHEN/THEN
         Assertions.assertThatThrownBy { EitherAssert.assertThat(rightValue).isLeft() }
             .isInstanceOf(AssertionError::class.java)

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_isRight_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/EitherAssert_isRight_Test.kt
@@ -29,9 +29,27 @@ internal class EitherAssert_isRight_Test {
     }
 
     @Test
+    internal fun `should pass if either is right-sided null`() {
+        // GIVEN
+        val rightValue = null.right()
+        // WHEN/THEN
+        EitherAssert.assertThat(rightValue).isRight()
+    }
+
+    @Test
     internal fun `should fail if either is left`() {
         // GIVEN
         val leftValue = "42".left()
+        // WHEN/THEN
+        Assertions.assertThatThrownBy { EitherAssert.assertThat(leftValue).isRight() }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(shouldBeRight(leftValue).create())
+    }
+
+    @Test
+    internal fun `should fail if either is left-sided null`() {
+        // GIVEN
+        val leftValue = null.left()
         // WHEN/THEN
         Assertions.assertThatThrownBy { EitherAssert.assertThat(leftValue).isRight() }
             .isInstanceOf(AssertionError::class.java)

--- a/src/test/kotlin/in/rcard/assertj/arrowcore/OptionAssert_hasValueSatisfying_Test.kt
+++ b/src/test/kotlin/in/rcard/assertj/arrowcore/OptionAssert_hasValueSatisfying_Test.kt
@@ -51,6 +51,6 @@ internal class OptionAssert_hasValueSatisfying_Test {
                 .hasValueSatisfying { assertThat(it).isEqualTo("something else") }
         }
         .isInstanceOf(AssertionError::class.java)
-        .hasMessage("\nexpected: \"something else\"\n but was: \"something\"")
+        .hasMessage("${System.lineSeparator()}expected: \"something else\"${System.lineSeparator()} but was: \"something\"")
     }
 }


### PR DESCRIPTION
Attempt at solving the issue presented in https://github.com/rcardin/assertj-arrow-core/issues/80

Adds support in EitherAssert for Eithers that contain left-sided or right-sided nullable types and null values.

The only place where the behavior didn't feel 100% completely clear was on `EitherShouldContainInstanceOf` where I could imagine that for example the value `null` could be an instance of `String?` - however I looked at the core AssertJ library which offers `IsInstanceOf`, and that will fail with the error message "java.lang.AssertionError: Expecting actual not to be null" if you pass a null value into an an `assertThat` and then call `isInstanceOf`

Additionally, I added tests for every path that I touched that could be nullable. However, strictly speaking whitebox a lot of these tests probably aren't necessary as there's no code adjustments for handling null values within an either, it is strictly a change to the type system and the compiler enforces that it's being handled in a null safe way. However, blackbox, I felt like having tests to ensure everything worked as expected with null values was overall worth it. Feel free to tell me if you'd like them pared back, removed, or otherwise adjusted.

One final small fix I completed in this PR was replacing some inline `\n`'s in tests with `${System.lineSeperator}` as these tests were failing for me in Main - I'm guessing I'm the first contributor running Windows, so my \r\n linebreaks don't play so nicely with those tests.

If there's anything you'd like me to do as a first time contributor, I'm happy to.

Hopefully there's nothing I missed, but please let me know if there is. Thanks!