### PR TITLE
Update Arrow Core Library to 2.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <java.version>17</java.version>
         <assertj-core.version>3.26.3</assertj-core.version>
         <kotlin-stdlib.version>2.0.21</kotlin-stdlib.version>
-        <arrow-core.version>1.2.4</arrow-core.version>
+        <arrow-core.version>2.1.2</arrow-core.version>
         <junit-jupiter.version>5.11.3</junit-jupiter.version>
         <dokka-maven-plugin.version>1.9.0</dokka-maven-plugin.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>


### PR DESCRIPTION
This fixes #84 in my local testing. I'm not sure if you'll want to update this library's major version to 2 to match arrow.