### PR TITLE
Patch to lastest assertj 3.27.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </licenses>
     <properties>
         <java.version>17</java.version>
-        <assertj-core.version>3.26.3</assertj-core.version>
+        <assertj-core.version>3.27.4</assertj-core.version>
         <kotlin-stdlib.version>2.0.21</kotlin-stdlib.version>
         <arrow-core.version>1.2.4</arrow-core.version>
         <junit-jupiter.version>5.11.3</junit-jupiter.version>


### PR DESCRIPTION
Optional: Some other patching while I was at it for #85 

No new test failures or build warnings, read through [the patch notes](https://github.com/assertj/assertj/releases) and didn't see any relevant opportunities or pitfalls between 3.26.3 and 3.27.4 and I didn't see a pre-existing renovate PR for this same update