### PR TITLE
Patch to lastest junit jupiter version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <assertj-core.version>3.26.3</assertj-core.version>
         <kotlin-stdlib.version>2.0.21</kotlin-stdlib.version>
         <arrow-core.version>1.2.4</arrow-core.version>
-        <junit-jupiter.version>5.11.3</junit-jupiter.version>
+        <junit-jupiter.version>5.13.4</junit-jupiter.version>
         <dokka-maven-plugin.version>1.9.0</dokka-maven-plugin.version>
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <kotlinx-coroutines-test.version>1.9.0</kotlinx-coroutines-test.version>


### PR DESCRIPTION
Similar to #86 , this is some optional patching (not a breakfix unlike #85), which built locally and, I saw nothing concerning in the [patch notes](https://docs.junit.org/5.13.4/release-notes/) ~and didn't see renovate opening up a PR for this.~